### PR TITLE
feat: Box 컴포넌트에 border-radius 속성 추가

### DIFF
--- a/src/components/layout/Box/index.tsx
+++ b/src/components/layout/Box/index.tsx
@@ -14,6 +14,7 @@ export type BoxProps = {
   minHeight?: Responsive<string>
   display?: Responsive<string>
   border?: Responsive<string>
+  borderRadius?: Responsive<string>
   overflow?: Responsive<string>
   margin?: Responsive<Space>
   marginTop?: Responsive<Space>
@@ -32,9 +33,12 @@ export type BoxProps = {
  * 레이아웃 조정에 사용한다
  * @description 기본적인 style 에 대해 반응형 적용 가능
  * @example <Box
-          width={'120px'}
-          height={'120px'}
-          backgroundColor={{ base: 'black', sm: 'gray', md: 'red' }}
+        width={'120px'}
+        height={'120px'}
+        backgroundColor={'red'}
+        margin={3}
+        border={'5px solid blue'}
+        borderRadius={'50%'}
       ></Box>
  */
 const Box = styled.div<BoxProps>`
@@ -47,6 +51,7 @@ const Box = styled.div<BoxProps>`
   ${(props) => toPropValue('min-height', props.minHeight, props.theme)}
   ${(props) => toPropValue('display', props.display, props.theme)}
   ${(props) => toPropValue('border', props.border, props.theme)}
+  ${(props) => toPropValue('border-radius', props.borderRadius, props.theme)}
   ${(props) => toPropValue('overflow', props.overflow, props.theme)}
   ${(props) => toPropValue('margin', props.margin, props.theme)}
   ${(props) => toPropValue('margin-top', props.marginTop, props.theme)}


### PR DESCRIPTION
## 작업사항

- [x] Box 컴포넌트 prop 에 borderRadius 추가 (string)
- [x] borderRadius 는 타입을 string 으로 정해두었으니 기존에 css 에서 쓰던 방식 (30px, 25%, ...) 등 모두 사용 가능

## 체크리스트

- [x] 불필요한 주석을 제거했는가?
- [ ] 코드리뷰를 요청했는가?
- [ ] 배포가 정상적으로 이루어졌는가?
- [ ] 단위테스트를 작성했는가?

---

- Close #8 
